### PR TITLE
Fix of custom header for error column

### DIFF
--- a/Stoner/Analysis.py
+++ b/Stoner/Analysis.py
@@ -753,7 +753,7 @@ class AnalysisMixin(object):
             err_calc = None
         adata, aname = self.__get_math_val(a)
         bdata, bname = self.__get_math_val(b)
-        if isinstance(header, tuple) and not header:
+        if isinstance(header, tuple) and len(header) == 2:
             header, err_header = header
         if header is None:
             header = "{}+{}".format(aname, bname)
@@ -1120,7 +1120,7 @@ class AnalysisMixin(object):
             err_calc = None
         adata, aname = self.__get_math_val(a)
         bdata, bname = self.__get_math_val(b)
-        if isinstance(header, tuple) and not header:
+        if isinstance(header, tuple) and len(header) == 2:
             header, err_header = header
         if header is None:
             header = "({}-{})/({}+{})".format(aname, bname, aname, bname)
@@ -1164,7 +1164,7 @@ class AnalysisMixin(object):
             err_calc = None
         adata, aname = self.__get_math_val(a)
         bdata, bname = self.__get_math_val(b)
-        if isinstance(header, tuple) and not header:
+        if isinstance(header, tuple) and len(header) == 2:
             header, err_header = header
         if header is None:
             header = "{}/{}".format(aname, bname)
@@ -1705,7 +1705,7 @@ class AnalysisMixin(object):
             err_calc = None
         adata, aname = self.__get_math_val(a)
         bdata, bname = self.__get_math_val(b)
-        if isinstance(header, tuple) and not header:
+        if isinstance(header, tuple) and len(header) == 2:
             header, err_header = header
         if header is None:
             header = "{}*{}".format(aname, bname)
@@ -2538,7 +2538,7 @@ class AnalysisMixin(object):
             err_calc = None
         adata, aname = self.__get_math_val(a)
         bdata, bname = self.__get_math_val(b)
-        if isinstance(header, tuple) and not header:
+        if isinstance(header, tuple) and len(header) == 2:
             header, err_header = header
         if header is None:
             header = "{}-{}".format(aname, bname)


### PR DESCRIPTION
When using basic math operations on columns, uncertainty columns can be created. However creation of the custom header for such column was not possible. In the first commit of these functions, there was a typo len(header) == 0, later changed to "not header". But neither worked, len of the tupple needs to be two, as for a and b variables on line 2530.