### PR TITLE
Fix of spline function with error column

### DIFF
--- a/Stoner/Analysis.py
+++ b/Stoner/Analysis.py
@@ -2352,8 +2352,8 @@ class AnalysisMixin(object):
         """
         _=self._col_args(xcol=xcol,ycol=ycol)
         if sigma is None and (isNone(_.yerr) or _.yerr):
-            if not isNone(_.yerr) and _.yerr[0] is not None:
-                sigma=1.0/(self//_.yerr[0])
+            if not isNone(_.yerr):
+                sigma=1.0/(self//_.yerr)
             else:
                 sigma=_np_.ones(len(self))
         replace=kargs.pop("replace",True)


### PR DESCRIPTION
Since _col_args at line #2353 is called with default scalar=True, _.yerr is just a number, never a list of values.